### PR TITLE
change: nose2 -> pytest-cov

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update \
         pyflakes \
         pylint \
         pytest-cov \
+        codacy-coverage \
         numpy \
         scipy \
         igraph \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,7 @@ RUN apt-get update \
         pep257 \
         pyflakes \
         pylint \
-        nose2 \
-        coverage \
+        pytest-cov \
         numpy \
         scipy \
         igraph \


### PR DESCRIPTION
pytest-cov gives out better coverage results as it also tests imports 
and **init**().

@satblip 
